### PR TITLE
[#feature] 로그아웃 api 호출 시 인증 불 필요 설정 추가

### DIFF
--- a/src/main/java/com/petpick/config/SecurityConfig.java
+++ b/src/main/java/com/petpick/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/v1/auth/google",
                                 "/api/v1/auth/token",
+                                "/api/v1/auth/logout",
                                 "/swagger-ui.html",
                                 "/swagger-ui/**",
                                 "/swagger-resources/**",


### PR DESCRIPTION
로그아웃 호출할 때 인증이 불필요해서 SecurityConfig 파일 수정했씁니다

# merge ㄱㄱ